### PR TITLE
Add CV link to About page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -216,6 +216,15 @@ export default function AboutPage() {
                     I&apos;m a Data Science and Artificial Intelligence student at Maastricht University with a passion for machine learning, computer vision, and full-stack development. My background spans AI research, marketing management, and software development internships.
                   </p>
                   <p className="text-gray-600 dark:text-gray-300 mb-4">
+                    <a
+                      href="/about/Achilleas_Leivadiotis_Resume.pdf"
+                      download
+                      className="text-blue-600 dark:text-blue-400 underline"
+                    >
+                      Download my CV (PDF)
+                    </a>
+                  </p>
+                  <p className="text-gray-600 dark:text-gray-300 mb-4">
                     Currently working as an AI & Environmental Analyst Trainee at EUROCONTROL MUAC, I&apos;m developing machine learning models for contrail detection and tracking to enhance aviation environmental efficiency.
                   </p>
                   <p className="text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
## Summary
- link to `Achilleas_Leivadiotis_Resume.pdf` from the About page so visitors can download it

## Testing
- `npm run lint` *(fails: Unknown options useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_6873ba093f5c832eb1686fab0c85ffad