### PR TITLE
Fix CV download style

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -215,15 +215,15 @@ export default function AboutPage() {
                   <p className="text-gray-600 dark:text-gray-300 mb-4">
                     I&apos;m a Data Science and Artificial Intelligence student at Maastricht University with a passion for machine learning, computer vision, and full-stack development. My background spans AI research, marketing management, and software development internships.
                   </p>
-                  <p className="text-gray-600 dark:text-gray-300 mb-4">
+                  <div className="text-gray-600 dark:text-gray-300 mb-4">
                     <a
                       href="/about/Achilleas_Leivadiotis_Resume.pdf"
                       download
-                      className="text-blue-600 dark:text-blue-400 underline"
+                      className="inline-flex items-center justify-center px-4 py-2 md:px-6 md:py-3 border border-transparent text-sm md:text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-all duration-300 hover:scale-105"
                     >
                       Download my CV (PDF)
                     </a>
-                  </p>
+                  </div>
                   <p className="text-gray-600 dark:text-gray-300 mb-4">
                     Currently working as an AI & Environmental Analyst Trainee at EUROCONTROL MUAC, I&apos;m developing machine learning models for contrail detection and tracking to enhance aviation environmental efficiency.
                   </p>


### PR DESCRIPTION
## Summary
- switch resume link to a Tailwind button on the about page

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6873de45d468832eb3e2792e49c9e891